### PR TITLE
Fix sqswatcher.py's removeHost

### DIFF
--- a/sqswatcher/sqswatcher.py
+++ b/sqswatcher/sqswatcher.py
@@ -182,7 +182,7 @@ def pollQueue(scheduler, q, t):
                             hostname = item['hostname']
 
                             if hostname:
-                                s.removeHost(hostname,cluster_user)
+                                s.removeHost(hostname,cluster_user,slots=0)
 
                             item.delete()
 


### PR DESCRIPTION
removeHost() currently requires 3 arguments. I don't know if slots should come from the message attributes here or whether it can just be 0. But without the parameter, I get an error when the cluster autoshrinks.