### PR TITLE
Leave SGE compute nodes as admin hosts

### DIFF
--- a/sqswatcher/plugins/sge.py
+++ b/sqswatcher/plugins/sge.py
@@ -95,10 +95,6 @@ report_variables      NONE
         time.sleep(1)
     ssh.close()
 
-    # Removing host as administrative host
-    command = ("/opt/sge/bin/lx-amd64/qconf -dh %s" % hostname)
-    __runSgeCommand(command)
-
     # Add the host to the qll.q
     command = ('/opt/sge/bin/lx-amd64/qconf -aattr hostgroup hostlist %s @allhosts' % hostname)
     __runSgeCommand(command)
@@ -109,6 +105,10 @@ report_variables      NONE
 
 def removeHost(hostname,cluster_user):
     log.info('Removing %s', hostname)
+
+    # Removing host as administrative host
+    command = ("/opt/sge/bin/lx-amd64/qconf -dh %s" % hostname)
+    __runSgeCommand(command)
 
     # Purge hostname from all.q
     command = ("/opt/sge/bin/lx-amd64/qconf -purge queue '*' all.q@%s" % hostname)


### PR DESCRIPTION
When an cfnCluster using SGE scales down lockHost is used to avoid having jobs scheduled on the compute node. However the `qmod -d all.q@hostname` must be run on an administration host. As part of the creation new nodes are removed from the administration host list. This breaks lockHost and occasionally will allow a job to schedule on the node just as the node shuts down. This leaves the job orphaned and the cluster in a state that is very difficult to recover from without recreating the cluster.

Fixes https://github.com/awslabs/cfncluster/issues/148