### PR TITLE
Fix license string in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,6 @@ setup(
         "Environment :: Console",
         "Programming Language :: Python",
         "Topic :: Scientific/Engineering",
-        "License :: Apache Software License",
+        "License :: OSI Approved :: Apache Software License",
     ],
 )


### PR DESCRIPTION
When the license for cfncluster-node was changed to Apache, the
classifier string was updated but not to the exact format that
PyPi wants, so PyPi rejected new versions.  Clean up the string
so that we can release 1.3.4.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>