### PR TITLE
Dropping Python 3.3 builds and adding 3.6.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ language: python
 python:
   - "2.6"
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
 
 install:
   - pip install -r requirements.txt


### PR DESCRIPTION
[Paramiko](http://www.paramiko.org/), a SSH library that sqswatcher uses, supports just Python 2.7/3.4+.
The Travis builds are failing because of this incompatibilty when installing
paramiko and cryptography from PyPi. Also adding 3.6 builds, which is the
current stable version of Python 3 which users are most likely to use.

Signed-off-by: Raghu Raja <craghun@amazon.com>