### PR TITLE
Bumping version to 1.4.1 as py_pi doesn't allow override

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def read(fname):
 
 console_scripts = ['sqswatcher = sqswatcher.sqswatcher:main', 
                    'nodewatcher = nodewatcher.nodewatcher:main']
-version = "1.4.0"
+version = "1.4.1"
 requires = ['boto>=2.48.0', 'paramiko>=2.3.1', 'python-dateutil>=2.6.1']
 
 if sys.version_info[:2] == (2, 6):


### PR DESCRIPTION
Overriding existing version is not possible in py_pi
hence had to bump version.

Signed-off-by: Mohan Gandhi <mohgan@amazon.com>