### PR TITLE
torque: fix variable name in getJobs error message

### DIFF
--- a/nodewatcher/plugins/torque.py
+++ b/nodewatcher/plugins/torque.py
@@ -41,7 +41,7 @@ def getJobs(hostname):
     try:
         status, output = runPipe(commands)
     except subprocess.CalledProcessError:
-        log.error("Failed to run %s\n" % _command)
+        log.error("Failed to run %s\n" % commands)
 
     if output == "":
         _jobs = False


### PR DESCRIPTION
*Issue:* The variable name used in the error message was wrong.

*Description of changes:* variable name fixed.