### PR TITLE
Unlock host in case self termination fails

### DIFF
--- a/nodewatcher/nodewatcher.py
+++ b/nodewatcher/nodewatcher.py
@@ -22,7 +22,7 @@ import tempfile
 import logging
 import boto3
 import ConfigParser
-import botocore.exceptions
+from botocore.exceptions import ClientError
 from botocore.config import Config
 import json
 import atexit
@@ -204,7 +204,7 @@ def main():
                             os.remove(_IDLETIME_FILE)
                             try:
                                 selfTerminate(asg_name, asg_conn, instance_id)
-                            except botocore.exceptions.ClientError as ex:
+                            except ClientError as ex:
                                 log.error('Failed to terminate instance: %s with exception %s' % (instance_id, ex))
                                 lockHost(s, hostname, unlock=True)
                         else:

--- a/nodewatcher/nodewatcher.py
+++ b/nodewatcher/nodewatcher.py
@@ -22,6 +22,7 @@ import tempfile
 import logging
 import boto3
 import ConfigParser
+import botocore.exceptions
 from botocore.config import Config
 import json
 import atexit
@@ -201,7 +202,11 @@ def main():
                         has_pending_jobs, error = hasPendingJobs(s)
                         if not error and not has_pending_jobs:
                             os.remove(_IDLETIME_FILE)
-                            selfTerminate(asg_name, asg_conn, instance_id)
+                            try:
+                                selfTerminate(asg_name, asg_conn, instance_id)
+                            except botocore.exceptions.ClientError as ex:
+                                log.error('Failed to terminate instance: %s with exception %s' % (instance_id, ex))
+                                lockHost(s, hostname, unlock=True)
                         else:
                             if has_pending_jobs:
                                 log.info('Queue has pending jobs. Not terminating instance')


### PR DESCRIPTION
There's a race condition where two instances can both try and terminate at the same time. The ASG will throw an exception if this makes it go under minSize. This catches that exception and unlocks the host.

Signed-off-by: Balaji Sridharan <fnubalaj@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
