### PR TITLE
Fix node package dependencies on CentOS6 (python 2.6)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
   - "3.6"
 
 install:
-  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install -r requirements26.txt; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then xargs -L 1 pip install < requirements26.txt; fi
   - if [[ $TRAVIS_PYTHON_VERSION != '2.6' ]]; then pip install -r requirements.txt; fi
   - pip install -e .
 

--- a/requirements26.txt
+++ b/requirements26.txt
@@ -1,1 +1,2 @@
+pycparser==2.18
 paramiko==2.3.2

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ if sys.version_info[:2] == (2, 6):
     # was not in stdlib until 2.7.
     requires.append('argparse>=1.4')
     requires.append('paramiko==2.3.2')
+    requires.append('pycparser==2.18')
 else:
     requires.append('paramiko>=2.3.2')
 


### PR DESCRIPTION
The root cause of the issue is that a new release of pycparser
https://pypi.org/project/pycparser/#history
which doesn't work with python 2.6 was released.
Our dependencies chain is

pycparser -> pynacl -> paramiko -> cfncluster-node

Signed-off-by: Luca Carrogu <carrogu@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
